### PR TITLE
Implement PCPlus4 module

### DIFF
--- a/modules/PC_Plus_4.v
+++ b/modules/PC_Plus_4.v
@@ -1,0 +1,7 @@
+module PCPlus4 (
+    input [63:0] pc,        // Current pc value
+	output [63:0] pc_plus_4 // pc+4 value
+);
+    assign pc_plus_4 = pc + 4;
+
+endmodule

--- a/testbenches/PC_Plus_4_tb.v
+++ b/testbenches/PC_Plus_4_tb.v
@@ -1,0 +1,33 @@
+`timescale 1ns/1ps
+
+module PCPlus4_tb;
+	reg [63:0] pc;
+	wire [63:0] pc_plus_4;
+
+    PCPlus4 dut (
+        .pc(pc),
+		.pc_plus_4(pc_plus_4)
+    );
+
+    initial begin
+        $dumpfile("testbenches/results/waveforms/PC_Plus_4_tb_result.vcd");
+        $dumpvars(0, dut);
+
+        // Test sequence
+        $display("==================== PCPlus4 Test START ====================\n");
+
+        pc = 64'h0000_0000_0000_0000; #1;
+        $display("PC: %h, PC+4: %h", pc, pc_plus_4);
+        
+		pc = 64'hDEAD_BEEF_DEAD_BEEF; #1;
+        $display("PC: %h, PC+4: %h", pc, pc_plus_4);
+		
+		pc = 64'hCAFE_BEBE_CAFE_BEBE; #1;
+        $display("PC: %h, PC+4: %h", pc, pc_plus_4);
+		
+		$display("\n====================  PCPlus4 Test END  ====================");
+		
+		$stop;
+    end
+
+endmodule

--- a/testbenches/results/PC_Plus_4_result.vvp
+++ b/testbenches/results/PC_Plus_4_result.vvp
@@ -1,0 +1,51 @@
+#! /usr/bin/vvp
+:ivl_version "12.0 (stable)";
+:ivl_delay_selection "TYPICAL";
+:vpi_time_precision - 12;
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/system.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/vhdl_sys.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/vhdl_textio.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/v2005_math.vpi";
+:vpi_module "/usr/lib/x86_64-linux-gnu/ivl/va_math.vpi";
+S_0x5588902b4430 .scope module, "PCPlus4_tb" "PCPlus4_tb" 2 3;
+ .timescale -9 -12;
+v0x5588902c8080_0 .var "pc", 63 0;
+v0x5588902c8170_0 .net "pc_plus_4", 63 0, L_0x5588902d82d0;  1 drivers
+S_0x5588902b45c0 .scope module, "dut" "PCPlus4" 2 7, 3 1 0, S_0x5588902b4430;
+ .timescale 0 0;
+    .port_info 0 /INPUT 64 "pc";
+    .port_info 1 /OUTPUT 64 "pc_plus_4";
+L_0x2b94c2033018 .functor BUFT 1, C4<0000000000000000000000000000000000000000000000000000000000000100>, C4<0>, C4<0>, C4<0>;
+v0x5588902a1370_0 .net/2u *"_ivl_0", 63 0, L_0x2b94c2033018;  1 drivers
+v0x5588902c7e80_0 .net "pc", 63 0, v0x5588902c8080_0;  1 drivers
+v0x5588902c7f60_0 .net "pc_plus_4", 63 0, L_0x5588902d82d0;  alias, 1 drivers
+L_0x5588902d82d0 .arith/sum 64, v0x5588902c8080_0, L_0x2b94c2033018;
+    .scope S_0x5588902b4430;
+T_0 ;
+    %vpi_call 2 13 "$dumpfile", "testbenches/results/waveforms/PC_Plus_4_tb_result.vcd" {0 0 0};
+    %vpi_call 2 14 "$dumpvars", 32'sb00000000000000000000000000000000, S_0x5588902b45c0 {0 0 0};
+    %vpi_call 2 17 "$display", "==================== PCPlus4 Test START ====================\012" {0 0 0};
+    %pushi/vec4 0, 0, 64;
+    %store/vec4 v0x5588902c8080_0, 0, 64;
+    %delay 1000, 0;
+    %vpi_call 2 20 "$display", "PC: %h, PC+4: %h", v0x5588902c8080_0, v0x5588902c8170_0 {0 0 0};
+    %pushi/vec4 3735928559, 0, 32;
+    %concati/vec4 3735928559, 0, 32;
+    %store/vec4 v0x5588902c8080_0, 0, 64;
+    %delay 1000, 0;
+    %vpi_call 2 23 "$display", "PC: %h, PC+4: %h", v0x5588902c8080_0, v0x5588902c8170_0 {0 0 0};
+    %pushi/vec4 3405692606, 0, 32;
+    %concati/vec4 3405692606, 0, 32;
+    %store/vec4 v0x5588902c8080_0, 0, 64;
+    %delay 1000, 0;
+    %vpi_call 2 26 "$display", "PC: %h, PC+4: %h", v0x5588902c8080_0, v0x5588902c8170_0 {0 0 0};
+    %vpi_call 2 28 "$display", "\012====================  PCPlus4 Test END  ====================" {0 0 0};
+    %vpi_call 2 30 "$stop" {0 0 0};
+    %end;
+    .thread T_0;
+# The file index is used to find the file name in the following table.
+:file_names 4;
+    "N/A";
+    "<interactive>";
+    "testbenches/PC_Plus_4_tb.v";
+    "modules/PC_Plus_4.v";

--- a/testbenches/results/waveforms/PC_Plus_4_tb_result.vcd
+++ b/testbenches/results/waveforms/PC_Plus_4_tb_result.vcd
@@ -1,0 +1,31 @@
+$date
+	Tue Jul  1 14:38:18 2025
+$end
+$version
+	Icarus Verilog
+$end
+$timescale
+	1ps
+$end
+$scope module PCPlus4_tb $end
+$scope module dut $end
+$var wire 64 ! pc [63:0] $end
+$var wire 64 " pc_plus_4 [63:0] $end
+$upscope $end
+$upscope $end
+$enddefinitions $end
+$comment Show the parameter values. $end
+$dumpall
+$end
+#0
+$dumpvars
+b100 "
+b0 !
+$end
+#1000
+b1101111010101101101111101110111111011110101011011011111011110011 "
+b1101111010101101101111101110111111011110101011011011111011101111 !
+#2000
+b1100101011111110101111101011111011001010111111101011111011000010 "
+b1100101011111110101111101011111011001010111111101011111010111110 !
+#3000


### PR DESCRIPTION
In an unprecedented leap for humanity, this PR introduces a truly groundbreaking module capable of accepting a program counter (PC) value and performing the mind-bogglingly sophisticated operation of adding 4 to it — before gracefully outputting the result.

Countless hours of theoretical breakthroughs and engineering prowess were funneled into achieving this state-of-the-art functionality. Rigorous verification has been conducted to ensure its flawless execution, laying the foundation for an entirely new era of PC handling.

Please be advised that the Turing Award committee is likely to reach out any day now regarding this historic advancement, so make the necessary preparations.