### PR TITLE
[Feat] Revise ID EX Register by increasing rs2 bit width to 6-bit

### DIFF
--- a/modules/ID_EX_Register.v
+++ b/modules/ID_EX_Register.v
@@ -34,7 +34,7 @@ module ID_EX_Register #(
     input wire [XLEN-1:0] ID_read_data1,
     input wire [XLEN-1:0] ID_read_data2,
     input wire [4:0] ID_rs1,
-    input wire [4:0] ID_rs2,
+    input wire [5:0] ID_rs2,
     input wire [XLEN-1:0] ID_imm,
     input wire [XLEN-1:0] ID_csr_read_data,
 
@@ -61,7 +61,7 @@ module ID_EX_Register #(
     output reg [XLEN-1:0] EX_read_data1,
     output reg [XLEN-1:0] EX_read_data2,
     output reg [4:0] EX_rs1,
-    output reg [4:0] EX_rs2,
+    output reg [5:0] EX_rs2,
     output reg [XLEN-1:0] EX_imm,
     output reg [XLEN-1:0] EX_csr_read_data
 );
@@ -90,7 +90,7 @@ always @(posedge clk or posedge reset) begin
         EX_read_data1 <= {XLEN{1'b0}};
         EX_read_data2 <= {XLEN{1'b0}};
         EX_rs1 <= 5'b0;
-        EX_rs2 <= 5'b0;
+        EX_rs2 <= 6'b0;
         EX_imm <= {XLEN{1'b0}};
         EX_csr_read_data <= {XLEN{1'b0}};
     end 
@@ -118,7 +118,7 @@ always @(posedge clk or posedge reset) begin
             EX_read_data1 <= {XLEN{1'b0}};
             EX_read_data2 <= {XLEN{1'b0}};
             EX_rs1 <= 5'b0;
-            EX_rs2 <= 5'b0;
+            EX_rs2 <= 6'b0;
             EX_imm <= {XLEN{1'b0}};
             EX_csr_read_data <= {XLEN{1'b0}};
         end 


### PR DESCRIPTION
This commit increases bit width of `rs2` in **ID_EX_Register** module for RV64I 6-bit `shamt` `rs2` instructions