### PR TITLE
[Feat] Revise ALU Controller syntax error when deannotating multiplier logics

### DIFF
--- a/modules/ALU_Controller.v
+++ b/modules/ALU_Controller.v
@@ -68,7 +68,6 @@ module ALUController (
 						`RTYPE_REMU: alu_op = `ALU_OP_REMU;
 					endcase
 				end
-			end
 				
 				else begin // I extension operations*/
 					case (funct3)
@@ -96,7 +95,7 @@ module ALUController (
 						`RTYPE_AND: alu_op = `ALU_OP_AND;
 						default: alu_op = `ALU_OP_NOP;
 					endcase
-                
+				end
             end
 			`OPCODE_ENVIRONMENT: begin
 				case (funct3)


### PR DESCRIPTION
This commit revises **ALU Controller**'s verilog syntax error that has been occurred when de-annotating multiplier logics.